### PR TITLE
Alle appens avhengigheter vil bli tilgjengelig ved lokal kjøring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ Microservice som brukes for å lese inn eventer fra DittNAV sin event-cache (dat
 
 # Kom i gang
 1. Bygg dittnav-event-handler ved å kjøre `gradle build`
-2. Start appen ved å kjøre filen EventHandlerApplication eller kjør `./gradlew runServer`.
+2. Start alle appens avhengigheter ved å kjøre `docker-compose -d`
+3. Start appen ved å kjøre filen EventHandlerApplication eller kjør `./gradlew runServer`.
+4. Appen nås på ´http://localhost:8092´
+
+# Feilsøking
+For å være sikker på at man får en ny tom database og tomme kafka-topics kan man kjøre kommandoen: `docker-compose down -v`
 
 # Henvendelser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: '3.7'
 services:
 
   postgres:
-    image: "postgres:11"
-    restart: "always"
+    image: "postgres:11.5"
     volumes:
       - "dittnav-event-cache-data:/var/lib/postgresql/data"
     ports:
@@ -14,7 +13,7 @@ services:
       POSTGRES_DB: "dittnav-event-cache-preprod"
 
   kafka:
-    image: landoop/fast-data-dev:2.2.0
+    image: "landoop/fast-data-dev:2.2.0"
     ports:
       - "3030:3030"
       - "9092:9092"
@@ -24,6 +23,24 @@ services:
       - "2181:2181"
     environment:
       - "ADV_HOST=127.0.0.1"
+
+  oidc-provier:
+    image: "navikt/pb-oidc-provider:0.5.0"
+    ports:
+      - "9000:9000"
+
+  oidc-provider-gui:
+    image: "navikt/pb-oidc-provider-gui:0.8.0"
+    ports:
+      - "5000:5000"
+
+  dittnav-event-aggregator:
+    image: "navikt/dittnav-event-aggregator:04325f31dff0076d87c6368e5bca58cd8a14e740"
+    network_mode: host
+    ports:
+      - "8080:8093"
+    depends_on:
+      - postgres
 
 volumes:
   dittnav-event-cache-data:

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/config/bootstrap.kt
@@ -10,6 +10,7 @@ import io.ktor.features.ContentNegotiation
 import io.ktor.features.DefaultHeaders
 import io.ktor.jackson.jackson
 import io.ktor.routing.routing
+import io.ktor.util.KtorExperimentalAPI
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.personbruker.dittnav.eventhandler.common.healthApi
 import no.nav.personbruker.dittnav.eventhandler.done.doneApi
@@ -17,8 +18,8 @@ import no.nav.personbruker.dittnav.eventhandler.informasjon.informasjonApi
 import no.nav.personbruker.dittnav.eventhandler.oppgave.oppgaveApi
 import no.nav.security.token.support.ktor.tokenValidationSupport
 
+@KtorExperimentalAPI
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
-    doDatabaseMigrationsIfApplicable(appContext)
     DefaultExports.initialize()
     install(DefaultHeaders)
 
@@ -45,11 +46,3 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
     }
 
 }
-
-private fun doDatabaseMigrationsIfApplicable(appContext: ApplicationContext) {
-    if (isRunningOnLocalhost()) {
-        Flyway.runFlywayMigrations(appContext.environment)
-    }
-}
-
-private fun isRunningOnLocalhost() = !ConfigUtil.isCurrentlyRunningOnNais()

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -12,9 +12,9 @@ ktor {
 no.nav.security.jwt {
   issuers = [
     {
-      issuer_name = issuer-localhost
+      issuer_name = "http://localhost-issuer"
       issuer_name = ${?OIDC_ISSUER}
-      discoveryurl = "http://metadata"
+      discoveryurl = "http://localhost:9000/.well-known/openid-configuration"
       discoveryurl = ${?OIDC_DISCOVERY_URL}
       accepted_audience = aud-localhost
       accepted_audience = ${?OIDC_ACCEPTED_AUDIENCE}


### PR DESCRIPTION
Dette inkluderer egen OIDC-provider og tilhørende GUI.
* Ved lokal kjøring forventes det OIDC-tokens utstedet av den lokalt kjørende OIDC-provider-en.
* Fjernet muligheten til å kjøre flyway-migrations ved lokal kjøring, fordi det ikke er denne appen som "eier" databasen. Kan gjøre dette nå fordi dittnav-event-aggregator vil sørge for at dette er i orden, både når appen er deploy-et og ved lokal kjøring i kombinasjon med docker-compose.

PB-199. Forenkle lokal testing med sikkerhet aktivert