### PR TITLE
Rydde opp i JSON-oppsett

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/config/bootstrap.kt
@@ -27,6 +27,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         jackson {
             enable(SerializationFeature.INDENT_OUTPUT)
             registerModule(JavaTimeModule())
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/informasjon/Informasjon.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/informasjon/Informasjon.kt
@@ -1,13 +1,14 @@
+import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.personbruker.dittnav.eventhandler.common.database.Brukernotifikasjon
 import java.time.ZonedDateTime
 
 data class Informasjon(
+        @JsonIgnore override val id: Int?,
         override val aktiv: Boolean,
         override val aktorId: String,
         override val dokumentId: String,
         override val eventId: String,
         override val eventTidspunkt: ZonedDateTime,
-        override val id: Int?,
         override val produsent: String,
         override val sikkerhetsnivaa: Int,
         override val sistOppdatert: ZonedDateTime,

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/Innboks.kt
@@ -1,10 +1,11 @@
 package no.nav.personbruker.dittnav.eventhandler.innboks
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.personbruker.dittnav.eventhandler.common.database.Brukernotifikasjon
 import java.time.ZonedDateTime
 
 data class Innboks (
-        override val id: Int,
+        @JsonIgnore override val id: Int,
         override val produsent: String,
         override val eventTidspunkt: ZonedDateTime,
         override val aktorId: String,

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/Oppgave.kt
@@ -1,15 +1,16 @@
 package no.nav.personbruker.dittnav.eventhandler.oppgave
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.personbruker.dittnav.eventhandler.common.database.Brukernotifikasjon
 import java.time.ZonedDateTime
 
 data class Oppgave(
+        @JsonIgnore override val id: Int?,
         override val aktiv: Boolean,
         override val aktorId: String,
         override val dokumentId: String,
         override val eventId: String,
         override val eventTidspunkt: ZonedDateTime,
-        override val id: Int?,
         override val produsent: String,
         override val sikkerhetsnivaa: Int,
         override val sistOppdatert: ZonedDateTime,


### PR DESCRIPTION
* Sørger for at datoer serialiseres på et format som er leslig for mennesker.
* Søger for at database ID-en per event ikke eksponeres ut, da dette kun er et internt anliggende. Det er eventID-er som vil bli brukt for å deaktivere eventer.

PB-283. Rydde opp i JSON-oppsett