### PR TITLE
Init-scriptet setter ikke verdi for systembruker-variabler hvis allerede satt

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,16 @@
 #!/bin/env sh
-echo "- exporting SERVICEUSER_USERNAME"
-export SERVICEUSER_USERNAME=$(cat /secret/serviceuser/username)
+if [ -z "$SERVICEUSER_USERNAME" ]
+then
+  echo "SERVICEUSER_USERNAME not set, exporting"
+  export SERVICEUSER_USERNAME=$(cat /secret/serviceuser/username)
+else
+  echo "SERVICEUSER_USERNAME already set"
+fi
 
-echo "- exporting SERVICEUSER_PASSWORD"
-export SERVICEUSER_PASSWORD=$(cat /secret/serviceuser/password)
+if [ -z "$SERVICEUSER_PASSWORD" ]
+then
+  echo "SERVICEUSER_PASSWORD not set, exporting"
+  export SERVICEUSER_PASSWORD=$(cat /secret/serviceuser/password)
+else
+  echo "SERVICEUSER_PASSWORD already set"
+fi


### PR DESCRIPTION
Dette hindrer at vi overskriver med en tom verdi hvis pathen ikke eksisterer. Dermed kan vi også slippe mountingen av dette i docker-compose.