### PR TITLE
Fjernet endepunkt som hentet feil antall inaktive brukernotifikasjoner

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/brukernotifikasjon/BrukernotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/brukernotifikasjon/BrukernotifikasjonService.kt
@@ -7,13 +7,6 @@ class BrukernotifikasjonService(
         private val database: Database
 ) {
 
-    suspend fun numberOfInactiveEvents(bruker: InnloggetBruker): Int {
-        val numberOfInactive = database.queryWithExceptionTranslation {
-            getNumberOfBrukernotifikasjonerByActiveStatus(bruker, false)
-        }
-        return numberOfInactive
-    }
-
     suspend fun numberOfActiveEvents(bruker: InnloggetBruker): Int {
         val numberOfActive = database.queryWithExceptionTranslation {
             getNumberOfBrukernotifikasjonerByActiveStatus(bruker, true)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/brukernotifikasjon/brukernotifikasjonApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/brukernotifikasjon/brukernotifikasjonApi.kt
@@ -33,14 +33,4 @@ fun Route.brukernotifikasjoner(brukernotifikasjonService: BrukernotifikasjonServ
         }
     }
 
-    get("/count/brukernotifikasjoner/inactive") {
-        try {
-            val numberOfEvents = brukernotifikasjonService.numberOfInactiveEvents(innloggetBruker)
-            call.respond(HttpStatusCode.OK, numberOfEvents)
-
-        } catch (exception: Exception) {
-            respondWithError(call, log, exception)
-        }
-    }
-
 }


### PR DESCRIPTION
Fjernet endepunkt som hentet feil antall inaktive brukernotifikasjoner. Det ikke tok ikke hensyn til inaktive brukernotifikasjoner som ble satt med synligFremTil.

PB-512: Rydde bort quickfix-er i dittnav.