### PR TITLE
Setter ned connection timeout

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/config/PostgresDatabase.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/config/PostgresDatabase.kt
@@ -56,7 +56,7 @@ class PostgresDatabase(env: Environment) : Database {
             config.minimumIdle = 0
             config.maxLifetime = 1800000
             config.maximumPoolSize = 2
-            config.connectionTimeout = 3000
+            config.connectionTimeout = 1000
             config.validationTimeout = 500
             config.idleTimeout = 30000
             config.isAutoCommit = false


### PR DESCRIPTION
Prøver å sette ned connection timeout. 

Vi opplever ofte feil med validering av connection mot postgres i tidsperioden 17:15-17:20. Prøver derfor å endre litt på connection-innstillingene.