### PR TITLE
Deploye handler til prod gcp

### DIFF
--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -47,9 +47,9 @@ spec:
             users:
               - name: eventhandler
         name: brukernotifikasjon-cache
-        diskSize: 10
+        diskSize: 100
         diskType: SSD
-        tier: db-f1-micro
+        tier: db-custom-2-12288
         type: POSTGRES_11
   kafka:
     pool: nav-prod


### PR DESCRIPTION
Endrer db config så den er lik aggregator sin db config. 

Vi deployer handler til prod gcp så vi kan teste aggregator. Aggregator har en avhengighet til [denne](https://github.com/navikt/dittnav-event-handler/blob/gcp/nais/prod-gcp/nais.yaml#L48) brukeren. Derfor må handler bli deployet.