### PR TITLE
Senker reserverte resurser basert på metrikker for reell bruk.

### DIFF
--- a/nais/dev-sbs/nais.yaml
+++ b/nais/dev-sbs/nais.yaml
@@ -37,5 +37,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
-      cpu: "500m"
+      cpu: "50m"
       memory: 384Mi

--- a/nais/prod-sbs/nais.yaml
+++ b/nais/prod-sbs/nais.yaml
@@ -37,5 +37,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
-      cpu: "500m"
+      cpu: "50m"
       memory: 384Mi


### PR DESCRIPTION
Senker reservert cpu til 50m for å matche gjennomsnittlig bruk per pod på en normal dag, som er rundt 13m.