### PR TITLE
Nye ingresser i GCP

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -34,6 +34,7 @@ spec:
       memory: 384Mi
   ingresses:
     - "https://dittnav-event-handler-gcp.dev.nav.no"
+    - "https://dittnav-event-handler.intern.dev.nav.no"
   gcp:
     permissions:
       - resource:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -34,6 +34,7 @@ spec:
       memory: 384Mi
   ingresses:
     - "https://dittnav-event-handler-gcp.nais.oera.no"
+    - "https://dittnav-event-handler.intern.nav.no"
   gcp:
     permissions:
       - resource:


### PR DESCRIPTION
*-gcp-ingressene ble lagt på for lenge siden, og er modne for utskifting før appen skal i prod. Beholder eksisterende i overgangsperioden slik at vi kan endre en og en app. Ut fra det jeg jeg kan lese meg til her, https://doc.nais.io/clusters/gcp/, gir de jeg har lagt inn her mening, men bare å foreslå noe annet :) 