### PR TITLE
Benytt samme datbase-container for alle int-testene

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedQueriesTest.kt
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BeskjedQueriesTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
 
     private val fodselsnummer = "12345"
     private val uid = "22"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/common/database/LocalPostgresDatabase.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/common/database/LocalPostgresDatabase.kt
@@ -5,12 +5,30 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.postgresql.util.PSQLException
-import java.lang.Thread.sleep
 
-class LocalPostgresDatabase : Database {
+class LocalPostgresDatabase private constructor() : Database {
 
     private val memDataSource: HikariDataSource
     private val container = TestPostgresqlContainer()
+
+    companion object {
+        private val instance by lazy {
+            LocalPostgresDatabase()
+        }
+
+        fun cleanDb(): LocalPostgresDatabase {
+            runBlocking {
+                instance.dbQuery {
+                    prepareStatement("delete from beskjed").execute()
+                    prepareStatement("delete from oppgave").execute()
+                    prepareStatement("delete from innboks").execute()
+                    prepareStatement("delete from statusoppdatering").execute()
+                    prepareStatement("delete from done").execute()
+                }
+            }
+            return instance
+        }
+    }
 
     init {
         container.start()

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/done/DoneQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/done/DoneQueriesTest.kt
@@ -23,7 +23,7 @@ import java.time.ZonedDateTime
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class DoneQueriesTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
     private val fodselsnummer = "123"
     private val systembruker = "x-dittnav"
     private val namespace = "localhost"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/event/EventTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/event/EventTest.kt
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EventTest {
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
 
     private val fodselsnummer = "12345678"
     private val uid = "22"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksQueriesTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.TestInstance
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InnboksQueriesTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
 
     private val fodselsnummer1 = "12345"
     private val fodselsnummer2 = "67890"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveQueriesTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.TestInstance
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OppgaveQueriesTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
     private val fodselsnummer = "12345"
     private val systembruker = "x-dittnav"
     private val namespace = "localhost"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/statistics/EventStatisticsServiceTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/statistics/EventStatisticsServiceTest.kt
@@ -27,7 +27,7 @@ import java.time.ZonedDateTime
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EventStatisticsServiceTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
     private val eventStatisticsService = EventStatisticsService(database)
 
     private val fodselsnummer = "12345"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/statistics/FrequencyDistributionStatisticsTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/statistics/FrequencyDistributionStatisticsTest.kt
@@ -21,7 +21,7 @@ import java.time.ZonedDateTime
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FrequencyDistributionStatisticsTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
     private val eventStatisticsService = EventStatisticsService(database)
 
     private val fodselsnummer = "12345"

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/statusoppdatering/StatusoppdateringQueriesTest.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/eventhandler/statusoppdatering/StatusoppdateringQueriesTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 class StatusoppdateringQueriesTest {
 
-    private val database = LocalPostgresDatabase()
+    private val database = LocalPostgresDatabase.cleanDb()
     private val bruker = TokenXUserObjectMother.createInnloggetBruker("12345")
     private val statusoppdateringEvents = StatusoppdateringObjectMother.getStatusoppdateringEvents(bruker)
     private val grupperingsid = "100${bruker.ident}"


### PR DESCRIPTION
Testetiden gikk fra rundt 52s til 7s