### PR TITLE
Legger til proxy-wait i et forsøk på å forebygge connection errors i andre apper.

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -5,6 +5,8 @@ metadata:
     team: min-side
   name: dittnav-event-handler
   namespace: min-side
+  annotations:
+    config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "10"
 spec:
   envFrom:
     - secret: dittnav-event-handler-secrets


### PR DESCRIPTION
Endrer hvor lenge linkerd-proxy skal vente ved graceful shutdown for å forebygge connection-errors hos andre apper.