### PR TITLE
Ekstern varsling status

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/Beskjed.kt
@@ -1,3 +1,4 @@
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
 import java.time.ZonedDateTime
 
 data class Beskjed(
@@ -16,7 +17,8 @@ data class Beskjed(
         val synligFremTil: ZonedDateTime?,
         val tekst: String,
         val link: String,
-        val aktiv: Boolean
+        val aktiv: Boolean,
+        val eksternVarslingInfo: EksternVarslingInfo
 ) {
     override fun toString(): String {
         return "Beskjed(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedDTO.kt
@@ -19,5 +19,5 @@ data class BeskjedDTO(
     val link: String,
     val aktiv: Boolean,
     val eksternVarslingSendt: Boolean,
-    val eksternVarslingkanaler: List<String>
+    val eksternVarslingKanaler: List<String>
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedDTO.kt
@@ -17,5 +17,7 @@ data class BeskjedDTO(
     val sistOppdatert: ZonedDateTime,
     val tekst: String,
     val link: String,
-    val aktiv: Boolean
+    val aktiv: Boolean,
+    val eksternVarslingSendt: Boolean,
+    val eksternVarslingkanaler: List<String>
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedQueries.kt
@@ -1,9 +1,12 @@
 package no.nav.personbruker.dittnav.eventhandler.beskjed
 
 import Beskjed
+import no.nav.personbruker.dittnav.eventhandler.common.database.getListFromSeparatedString
 import no.nav.personbruker.dittnav.eventhandler.common.database.getNullableUtcTimeStamp
 import no.nav.personbruker.dittnav.eventhandler.common.database.getUtcTimeStamp
 import no.nav.personbruker.dittnav.eventhandler.common.database.mapList
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingStatus
 import no.nav.personbruker.dittnav.eventhandler.statistics.EventCountForProducer
 import java.sql.Connection
 import java.sql.ResultSet
@@ -12,6 +15,15 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
+private val baseSelectQuery = """
+    SELECT 
+        beskjed.*,
+        dok_status.status as doknotifikasjon_status,
+        dok_status.kanaler as doknotifikasjon_kanaler
+    FROM beskjed
+        LEFT JOIN DOKNOTIFIKASJON_STATUS_BESKJED as dok_status on beskjed.eventId = dok_status.eventId
+""".trimMargin()
+
 fun Connection.getInaktivBeskjedForFodselsnummer(fodselsnummer: String): List<Beskjed> =
         getBeskjedForFodselsnummerByAktiv(fodselsnummer, false)
 
@@ -19,23 +31,7 @@ fun Connection.getAktivBeskjedForFodselsnummer(fodselsnummer: String): List<Besk
         getBeskjedForFodselsnummerByAktiv(fodselsnummer, true)
 
 private fun Connection.getBeskjedForFodselsnummerByAktiv(fodselsnummer: String, aktiv: Boolean): List<Beskjed> =
-    prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId, 
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |synligFremTil,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM beskjed WHERE fodselsnummer = ? AND aktiv = ?""".trimMargin())
+    prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND aktiv = ?""".trimMargin())
         .use {
             it.setString(1, fodselsnummer)
             it.setBoolean(2, aktiv)
@@ -45,23 +41,7 @@ private fun Connection.getBeskjedForFodselsnummerByAktiv(fodselsnummer: String, 
         }
 
 fun Connection.getAllBeskjedForFodselsnummer(fodselsnummer: String): List<Beskjed> =
-    prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId, 
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |synligFremTil,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM beskjed WHERE fodselsnummer = ?""".trimMargin())
+    prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ?""".trimMargin())
                 .use {
                     it.setString(1, fodselsnummer)
                     it.executeQuery().mapList {
@@ -70,23 +50,7 @@ fun Connection.getAllBeskjedForFodselsnummer(fodselsnummer: String): List<Beskje
                 }
 
 fun Connection.getBeskjedByIds(fodselsnummer: String, eventId: String): List<Beskjed> =
-        prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId, 
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |synligFremTil,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM beskjed WHERE fodselsnummer = ? AND eventId = ?""".trimMargin())
+        prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND beskjed.eventId = ?""".trimMargin())
                 .use {
                     it.setString(1, fodselsnummer)
                     it.setString(2, eventId)
@@ -96,23 +60,7 @@ fun Connection.getBeskjedByIds(fodselsnummer: String, eventId: String): List<Bes
                 }
 
 fun Connection.getAllGroupedBeskjedEventsByIds(fodselsnummer: String, grupperingsid: String, appnavn: String): List<Beskjed> =
-        prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId, 
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |synligFremTil,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM beskjed WHERE fodselsnummer = ? AND grupperingsId = ? AND appnavn = ?""".trimMargin())
+        prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND grupperingsId = ? AND appnavn = ?""".trimMargin())
                 .use {
                     it.setString(1, fodselsnummer)
                     it.setString(2, grupperingsid)
@@ -151,22 +99,34 @@ fun Connection.getAllGroupedBeskjedEventsByProducer(): List<EventCountForProduce
 
 fun ResultSet.toBeskjed(): Beskjed {
     return Beskjed(
-            id = getInt("id"),
-            fodselsnummer = getString("fodselsnummer"),
-            grupperingsId = getString("grupperingsId"),
-            eventId = getString("eventId"),
-            eventTidspunkt = ZonedDateTime.ofInstant(getUtcTimeStamp("eventTidspunkt").toInstant(), ZoneId.of("Europe/Oslo")),
-            produsent = getString("appnavn") ?: "",
-            systembruker = getString("systembruker"),
-            namespace = getString("namespace"),
-            appnavn = getString("appnavn"),
-            sikkerhetsnivaa = getInt("sikkerhetsnivaa"),
-            sistOppdatert = ZonedDateTime.ofInstant(getUtcTimeStamp("sistOppdatert").toInstant(), ZoneId.of("Europe/Oslo")),
-            synligFremTil = getNullableZonedDateTime("synligFremTil"),
-            tekst = getString("tekst"),
-            link = getString("link"),
-            aktiv = getBoolean("aktiv"),
-            forstBehandlet = ZonedDateTime.ofInstant(getUtcTimeStamp("forstBehandlet").toInstant(), ZoneId.of("Europe/Oslo")),
+        id = getInt("id"),
+        fodselsnummer = getString("fodselsnummer"),
+        grupperingsId = getString("grupperingsId"),
+        eventId = getString("eventId"),
+        eventTidspunkt = ZonedDateTime.ofInstant(getUtcTimeStamp("eventTidspunkt").toInstant(), ZoneId.of("Europe/Oslo")),
+        produsent = getString("appnavn") ?: "",
+        systembruker = getString("systembruker"),
+        namespace = getString("namespace"),
+        appnavn = getString("appnavn"),
+        sikkerhetsnivaa = getInt("sikkerhetsnivaa"),
+        sistOppdatert = ZonedDateTime.ofInstant(getUtcTimeStamp("sistOppdatert").toInstant(), ZoneId.of("Europe/Oslo")),
+        synligFremTil = getNullableZonedDateTime("synligFremTil"),
+        tekst = getString("tekst"),
+        link = getString("link"),
+        aktiv = getBoolean("aktiv"),
+        forstBehandlet = ZonedDateTime.ofInstant(getUtcTimeStamp("forstBehandlet").toInstant(), ZoneId.of("Europe/Oslo")),
+        eksternVarslingInfo = toEksternVarslingInfo()
+    )
+}
+
+private fun ResultSet.toEksternVarslingInfo(): EksternVarslingInfo {
+    val eksternVarslingSendt = getString("doknotifikasjon_status") == EksternVarslingStatus.OVERSENDT.name
+
+    return EksternVarslingInfo(
+        bestilt = getBoolean("eksternVarsling"),
+        prefererteKanaler = getListFromSeparatedString("prefererteKanaler"),
+        sendt = eksternVarslingSendt,
+        sendteKanaler = getListFromSeparatedString("doknotifikasjon_kanaler")
     )
 }
 
@@ -182,23 +142,7 @@ fun Connection.getRecentAktivBeskjedForFodselsnummer(fodselsnummer: String, from
 
 
 private fun Connection.getRecentBeskjedForFodselsnummerByAktiv(fodselsnummer: String, aktiv: Boolean, fromDate: LocalDate): List<Beskjed> =
-        prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId, 
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |synligFremTil,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM beskjed WHERE fodselsnummer = ? AND aktiv = ? AND forstBehandlet > ?""".trimMargin())
+        prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND aktiv = ? AND forstBehandlet > ?""".trimMargin())
                 .use {
                     it.setString(1, fodselsnummer)
                     it.setBoolean(2, aktiv)
@@ -209,23 +153,7 @@ private fun Connection.getRecentBeskjedForFodselsnummerByAktiv(fodselsnummer: St
                 }
 
 fun Connection.getAllRecentBeskjedForFodselsnummer(fodselsnummer: String, fromDate: LocalDate): List<Beskjed> =
-    prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId, 
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |synligFremTil,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM beskjed WHERE fodselsnummer = ?
+    prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ?
             |AND forstBehandlet > ?""".trimMargin())
         .use {
             it.setString(1, fodselsnummer)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedTransformers.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedTransformers.kt
@@ -14,5 +14,5 @@ fun Beskjed.toDTO() = BeskjedDTO(
     aktiv = aktiv,
     forstBehandlet = forstBehandlet,
     eksternVarslingSendt = eksternVarslingInfo.sendt,
-    eksternVarslingkanaler = eksternVarslingInfo.sendteKanaler
+    eksternVarslingKanaler = eksternVarslingInfo.sendteKanaler
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedTransformers.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedTransformers.kt
@@ -12,5 +12,7 @@ fun Beskjed.toDTO() = BeskjedDTO(
     tekst = tekst,
     link = link,
     aktiv = aktiv,
-    forstBehandlet = forstBehandlet
+    forstBehandlet = forstBehandlet,
+    eksternVarslingSendt = eksternVarslingInfo.sendt,
+    eksternVarslingkanaler = eksternVarslingInfo.sendteKanaler
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/common/database/resultSetUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/common/database/resultSetUtil.kt
@@ -42,3 +42,12 @@ fun ResultSet.getUtcTimeStamp(label: String): Timestamp = getTimestamp(label, Ca
 
 fun ResultSet.getNullableUtcTimeStamp(label: String): Timestamp? = getTimestamp(label, Calendar.getInstance())
 
+fun ResultSet.getListFromSeparatedString(columnLabel: String, separator: String = ","): List<String> {
+    val stringValue = getString(columnLabel)
+    return if(stringValue.isNullOrEmpty()) {
+        emptyList()
+    }
+    else {
+        stringValue.split(separator)
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/EksternVarslingInfo.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/EksternVarslingInfo.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.eventhandler.eksternvarsling
+
+data class EksternVarslingInfo(
+    val bestilt: Boolean,
+    val sendt: Boolean,
+    val prefererteKanaler: List<String>,
+    val sendteKanaler: List<String>
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/EksternVarslingStatus.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/EksternVarslingStatus.kt
@@ -1,0 +1,5 @@
+package no.nav.personbruker.dittnav.eventhandler.eksternvarsling
+
+enum class EksternVarslingStatus {
+    FEILET, INFO, OVERSENDT, FERDIGSTILT
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/Innboks.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventhandler.innboks
 
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
 import java.time.ZonedDateTime
 
 data class Innboks(
@@ -17,7 +18,8 @@ data class Innboks(
         val link: String,
         val sikkerhetsnivaa: Int,
         val sistOppdatert: ZonedDateTime,
-        val aktiv: Boolean
+        val aktiv: Boolean,
+        val eksternVarslingInfo: EksternVarslingInfo
 ) {
     override fun toString(): String {
         return "Innboks(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksDTO.kt
@@ -19,5 +19,5 @@ data class InnboksDTO(
     val sistOppdatert: ZonedDateTime,
     val aktiv: Boolean,
     val eksternVarslingSendt: Boolean,
-    val eksternVarslingkanaler: List<String>
+    val eksternVarslingKanaler: List<String>
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksDTO.kt
@@ -17,5 +17,7 @@ data class InnboksDTO(
     val link: String,
     val sikkerhetsnivaa: Int,
     val sistOppdatert: ZonedDateTime,
-    val aktiv: Boolean
+    val aktiv: Boolean,
+    val eksternVarslingSendt: Boolean,
+    val eksternVarslingkanaler: List<String>
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/innboksTransformers.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/innboksTransformers.kt
@@ -10,5 +10,7 @@ fun Innboks.toDTO() = InnboksDTO(
     sikkerhetsnivaa = sikkerhetsnivaa,
     sistOppdatert = sistOppdatert,
     aktiv = aktiv,
-    forstBehandlet = forstBehandlet
+    forstBehandlet = forstBehandlet,
+    eksternVarslingSendt = eksternVarslingInfo.sendt,
+    eksternVarslingkanaler = eksternVarslingInfo.sendteKanaler
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/innboksTransformers.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/innboksTransformers.kt
@@ -12,5 +12,5 @@ fun Innboks.toDTO() = InnboksDTO(
     aktiv = aktiv,
     forstBehandlet = forstBehandlet,
     eksternVarslingSendt = eksternVarslingInfo.sendt,
-    eksternVarslingkanaler = eksternVarslingInfo.sendteKanaler
+    eksternVarslingKanaler = eksternVarslingInfo.sendteKanaler
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/Oppgave.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventhandler.oppgave
 
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
 import java.time.ZonedDateTime
 
 data class Oppgave(
@@ -17,7 +18,8 @@ data class Oppgave(
         val sistOppdatert: ZonedDateTime,
         val tekst: String,
         val link: String,
-        val aktiv: Boolean
+        val aktiv: Boolean,
+        val eksternVarslingInfo: EksternVarslingInfo
 ) {
     override fun toString(): String {
         return "Oppgave(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveDTO.kt
@@ -19,6 +19,6 @@ data class OppgaveDTO(
     val link: String,
     val aktiv: Boolean,
     val eksternVarslingSendt: Boolean,
-    val eksternVarslingkanaler: List<String>
+    val eksternVarslingKanaler: List<String>
 )
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveDTO.kt
@@ -17,6 +17,8 @@ data class OppgaveDTO(
     val sistOppdatert: ZonedDateTime,
     val tekst: String,
     val link: String,
-    val aktiv: Boolean
+    val aktiv: Boolean,
+    val eksternVarslingSendt: Boolean,
+    val eksternVarslingkanaler: List<String>
 )
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveQueries.kt
@@ -1,8 +1,11 @@
 package no.nav.personbruker.dittnav.eventhandler.oppgave
 
 import no.nav.personbruker.dittnav.eventhandler.common.database.convertIfUnlikelyDate
+import no.nav.personbruker.dittnav.eventhandler.common.database.getListFromSeparatedString
 import no.nav.personbruker.dittnav.eventhandler.common.database.getUtcTimeStamp
 import no.nav.personbruker.dittnav.eventhandler.common.database.mapList
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingStatus
 import no.nav.personbruker.dittnav.eventhandler.statistics.EventCountForProducer
 import java.sql.Connection
 import java.sql.ResultSet
@@ -11,6 +14,15 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
+private val baseSelectQuery = """
+    SELECT 
+        oppgave.*,
+        dok_status.status as doknotifikasjon_status,
+        dok_status.kanaler as doknotifikasjon_kanaler
+    FROM oppgave
+        LEFT JOIN DOKNOTIFIKASJON_STATUS_OPPGAVE as dok_status on oppgave.eventId = dok_status.eventId
+""".trimMargin()
+
 fun Connection.getInaktivOppgaveForFodselsnummer(fodselsnummer: String): List<Oppgave> =
         getOppgaveForFodselsnummerByAktiv(fodselsnummer, false)
 
@@ -18,22 +30,7 @@ fun Connection.getAktivOppgaveForFodselsnummer(fodselsnummer: String): List<Oppg
         getOppgaveForFodselsnummerByAktiv(fodselsnummer, true)
 
 private fun Connection.getOppgaveForFodselsnummerByAktiv(fodselsnummer: String, aktiv: Boolean): List<Oppgave> =
-    prepareStatement("""SELECT
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId,
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM oppgave WHERE fodselsnummer = ? AND aktiv = ?""".trimMargin())
+    prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND aktiv = ?""".trimMargin())
         .use {
             it.setString(1, fodselsnummer)
             it.setBoolean(2, aktiv)
@@ -43,22 +40,7 @@ private fun Connection.getOppgaveForFodselsnummerByAktiv(fodselsnummer: String, 
         }
 
 fun Connection.getAllOppgaveForFodselsnummer(fodselsnummer: String): List<Oppgave> =
-        prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId,
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM oppgave WHERE fodselsnummer = ?""".trimMargin())
+        prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ?""".trimMargin())
                 .use {
                     it.setString(1, fodselsnummer)
                     it.executeQuery().mapList {
@@ -67,22 +49,7 @@ fun Connection.getAllOppgaveForFodselsnummer(fodselsnummer: String): List<Oppgav
                 }
 
 fun Connection.getAllGroupedOppgaveEventsByIds(fodselsnummer: String, grupperingsid: String, appnavn: String): List<Oppgave> =
-        prepareStatement("""SELECT
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId,
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM oppgave WHERE fodselsnummer = ? AND grupperingsid = ? AND appnavn = ?""".trimMargin())
+        prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND grupperingsid = ? AND appnavn = ?""".trimMargin())
                 .use {
                     it.setString(1, fodselsnummer)
                     it.setString(2, grupperingsid)
@@ -96,21 +63,33 @@ private fun ResultSet.toOppgave(): Oppgave {
     val rawEventTidspunkt = getUtcTimeStamp("eventTidspunkt")
     val verifiedEventTidspunkt = convertIfUnlikelyDate(rawEventTidspunkt)
     return Oppgave(
-            id = getInt("id"),
-            produsent = getString("appnavn") ?: "",
-            systembruker = getString("systembruker"),
-            namespace = getString("namespace"),
-            appnavn = getString("appnavn"),
-            eventTidspunkt = verifiedEventTidspunkt,
-            fodselsnummer = getString("fodselsnummer"),
-            eventId = getString("eventId"),
-            grupperingsId = getString("grupperingsId"),
-            tekst = getString("tekst"),
-            link = getString("link"),
-            sikkerhetsnivaa = getInt("sikkerhetsnivaa"),
-            sistOppdatert = ZonedDateTime.ofInstant(getUtcTimeStamp("sistOppdatert").toInstant(), ZoneId.of("Europe/Oslo")),
-            aktiv = getBoolean("aktiv"),
-            forstBehandlet = ZonedDateTime.ofInstant(getUtcTimeStamp("forstBehandlet").toInstant(), ZoneId.of("Europe/Oslo"))
+        id = getInt("id"),
+        produsent = getString("appnavn") ?: "",
+        systembruker = getString("systembruker"),
+        namespace = getString("namespace"),
+        appnavn = getString("appnavn"),
+        eventTidspunkt = verifiedEventTidspunkt,
+        fodselsnummer = getString("fodselsnummer"),
+        eventId = getString("eventId"),
+        grupperingsId = getString("grupperingsId"),
+        tekst = getString("tekst"),
+        link = getString("link"),
+        sikkerhetsnivaa = getInt("sikkerhetsnivaa"),
+        sistOppdatert = ZonedDateTime.ofInstant(getUtcTimeStamp("sistOppdatert").toInstant(), ZoneId.of("Europe/Oslo")),
+        aktiv = getBoolean("aktiv"),
+        forstBehandlet = ZonedDateTime.ofInstant(getUtcTimeStamp("forstBehandlet").toInstant(), ZoneId.of("Europe/Oslo")),
+        eksternVarslingInfo = toEksternVarslingInfo()
+    )
+}
+
+private fun ResultSet.toEksternVarslingInfo(): EksternVarslingInfo {
+    val eksternVarslingSendt = getString("doknotifikasjon_status") == EksternVarslingStatus.OVERSENDT.name
+
+    return EksternVarslingInfo(
+        bestilt = getBoolean("eksternVarsling"),
+        prefererteKanaler = getListFromSeparatedString("prefererteKanaler"),
+        sendt = eksternVarslingSendt,
+        sendteKanaler = getListFromSeparatedString("doknotifikasjon_kanaler")
     )
 }
 
@@ -148,22 +127,7 @@ fun Connection.getRecentAktivOppgaveForFodselsnummer(fodselsnummer: String, from
     getRecentOppgaveForFodselsnummerByAktiv(fodselsnummer, true, fromDate)
 
 private fun Connection.getRecentOppgaveForFodselsnummerByAktiv(fodselsnummer: String, aktiv: Boolean, fromDate: LocalDate): List<Oppgave> =
-    prepareStatement("""SELECT
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId,
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM oppgave WHERE fodselsnummer = ? AND aktiv = ? AND forstBehandlet > ?""".trimMargin())
+    prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ? AND aktiv = ? AND forstBehandlet > ?""".trimMargin())
         .use {
             it.setString(1, fodselsnummer)
             it.setBoolean(2, aktiv)
@@ -174,22 +138,7 @@ private fun Connection.getRecentOppgaveForFodselsnummerByAktiv(fodselsnummer: St
         }
 
 fun Connection.getAllRecentOppgaveForFodselsnummer(fodselsnummer: String, fromDate: LocalDate): List<Oppgave> =
-    prepareStatement("""SELECT 
-            |id,
-            |eventTidspunkt,
-            |fodselsnummer,
-            |eventId,
-            |grupperingsId,
-            |tekst,
-            |link,
-            |sikkerhetsnivaa,
-            |sistOppdatert,
-            |aktiv,
-            |systembruker,
-            |namespace,
-            |appnavn,
-            |forstBehandlet
-            |FROM oppgave WHERE fodselsnummer = ?
+    prepareStatement("""$baseSelectQuery WHERE fodselsnummer = ?
             |AND forstBehandlet > ?""".trimMargin())
         .use {
             it.setString(1, fodselsnummer)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveTransformers.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveTransformers.kt
@@ -10,5 +10,7 @@ fun Oppgave.toDTO() = OppgaveDTO(
     tekst = tekst,
     link = link,
     aktiv = aktiv,
-    forstBehandlet = forstBehandlet
+    forstBehandlet = forstBehandlet,
+    eksternVarslingSendt = eksternVarslingInfo.sendt,
+    eksternVarslingkanaler = eksternVarslingInfo.sendteKanaler
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveTransformers.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveTransformers.kt
@@ -12,5 +12,5 @@ fun Oppgave.toDTO() = OppgaveDTO(
     aktiv = aktiv,
     forstBehandlet = forstBehandlet,
     eksternVarslingSendt = eksternVarslingInfo.sendt,
-    eksternVarslingkanaler = eksternVarslingInfo.sendteKanaler
+    eksternVarslingKanaler = eksternVarslingInfo.sendteKanaler
 )

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/BeskjedObjectMother.kt
@@ -1,6 +1,9 @@
 package no.nav.personbruker.dittnav.eventhandler.beskjed
 
 import Beskjed
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfoObjectMother
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfoObjectMother.createEskternVarslingInfo
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -23,6 +26,7 @@ object BeskjedObjectMother {
     val defaultLink = "https://nav.no/systemX/$defaultFodselsnummer"
     val defaultSistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo"))
     val defaultSikkerhetsnivaa = 4
+    val defaultEksternVarslinginfo = createEskternVarslingInfo()
 
     fun createBeskjed(
         id: Int = ++idIncrementor,
@@ -40,7 +44,8 @@ object BeskjedObjectMother {
         tekst: String = defaultTekst,
         link: String = defaultLink,
         sistOppdatert: ZonedDateTime = defaultSistOppdatert,
-        sikkerhetsnivaa: Int = defaultSikkerhetsnivaa
+        sikkerhetsnivaa: Int = defaultSikkerhetsnivaa,
+        eksternVarslingInfo: EksternVarslingInfo = defaultEksternVarslinginfo
     ): Beskjed {
         return Beskjed(
             id = id,
@@ -58,7 +63,8 @@ object BeskjedObjectMother {
             sistOppdatert = sistOppdatert,
             synligFremTil = synligFremTil,
             sikkerhetsnivaa = sikkerhetsnivaa,
-            aktiv = aktiv
+            aktiv = aktiv,
+            eksternVarslingInfo = eksternVarslingInfo
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedTestQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/beskjed/beskjedTestQueries.kt
@@ -5,8 +5,8 @@ import java.sql.Connection
 import java.sql.Types
 
 fun Connection.createBeskjed(beskjeder: List<Beskjed>) =
-        prepareStatement("""INSERT INTO beskjed(id, systembruker, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv, synligFremTil, namespace, appnavn, forstBehandlet)
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")
+        prepareStatement("""INSERT INTO beskjed(id, systembruker, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv, synligFremTil, namespace, appnavn, forstBehandlet, eksternVarsling, prefererteKanaler)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")
                 .use {
                     beskjeder.forEach { beskjed ->
                         run {
@@ -25,6 +25,8 @@ fun Connection.createBeskjed(beskjeder: List<Beskjed>) =
                             it.setString(13, beskjed.namespace)
                             it.setString(14, beskjed.appnavn)
                             it.setObject(15, beskjed.forstBehandlet.toLocalDateTime(), Types.TIMESTAMP)
+                            it.setBoolean(16, beskjed.eksternVarslingInfo.bestilt)
+                            it.setString(17, beskjed.eksternVarslingInfo.prefererteKanaler.joinToString(","))
                             it.addBatch()
                         }
                     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/DoknotifikasjonStatusDto.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/DoknotifikasjonStatusDto.kt
@@ -1,0 +1,9 @@
+package no.nav.personbruker.dittnav.eventhandler.eksternvarsling
+
+data class DoknotifikasjonStatusDto(
+    val eventId: String,
+    val status: String,
+    val melding: String,
+    val distribusjonsId: Long?,
+    val kanaler: String
+)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/EksternVarslingInfoObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/EksternVarslingInfoObjectMother.kt
@@ -1,0 +1,21 @@
+package no.nav.personbruker.dittnav.eventhandler.eksternvarsling
+
+object EksternVarslingInfoObjectMother {
+
+    private val defaultBestilt = false
+    private val defaultPrefererteKanaler = listOf<String>()
+    private val defaultSendt = true
+    private val defaultSendteKanaler = listOf<String>()
+
+    fun createEskternVarslingInfo(
+        bestilt: Boolean = defaultBestilt,
+        prefererteKanaler: List<String> = defaultPrefererteKanaler,
+        sendt: Boolean = defaultSendt,
+        sendteKanaler: List<String> = defaultSendteKanaler
+    ) = EksternVarslingInfo(
+            bestilt = bestilt,
+            prefererteKanaler = prefererteKanaler,
+            sendt = sendt,
+            sendteKanaler = sendteKanaler
+        )
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/doknotifikasjonStatusTestQuery.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/eksternvarsling/doknotifikasjonStatusTestQuery.kt
@@ -1,0 +1,57 @@
+package no.nav.personbruker.dittnav.eventhandler.eksternvarsling
+
+import java.sql.Connection
+
+private fun insertQuery(type: String) = """
+    insert into doknotifikasjon_status_$type (eventId, status, melding, distribusjonsId, kanaler, antall_oppdateringer)
+        values (?, ?, ?, ?, ?, 1)
+""".trimIndent()
+
+private val insertStatusBeskjed = insertQuery("beskjed")
+private val insertStatusOppgave = insertQuery("oppgave")
+private val insertStatusInnboks = insertQuery("innboks")
+
+fun Connection.createDoknotStatusBeskjed(status: DoknotifikasjonStatusDto) {
+    prepareStatement(insertStatusBeskjed).use {
+        it.setString(1, status.eventId)
+        it.setString(2, status.status)
+        it.setString(3, status.melding)
+        it.setObject(4, status.distribusjonsId)
+        it.setString(5, status.kanaler)
+        it.executeUpdate()
+    }
+}
+
+fun Connection.createDoknotStatusOppgave(status: DoknotifikasjonStatusDto) {
+    prepareStatement(insertStatusOppgave).use {
+        it.setString(1, status.eventId)
+        it.setString(2, status.status)
+        it.setString(3, status.melding)
+        it.setObject(4, status.distribusjonsId)
+        it.setString(5, status.kanaler)
+        it.executeUpdate()
+    }
+}
+
+fun Connection.createDoknotStatusInnboks(status: DoknotifikasjonStatusDto) {
+    prepareStatement(insertStatusInnboks).use {
+        it.setString(1, status.eventId)
+        it.setString(2, status.status)
+        it.setString(3, status.melding)
+        it.setObject(4, status.distribusjonsId)
+        it.setString(5, status.kanaler)
+        it.executeUpdate()
+    }
+}
+
+fun Connection.deleteDoknotStatusBeskjed() {
+    prepareStatement("delete from doknotifikasjon_status_beskjed").executeUpdate()
+}
+
+fun Connection.deleteDoknotStatusOppgave() {
+    prepareStatement("delete from doknotifikasjon_status_oppgave").executeUpdate()
+}
+
+fun Connection.deleteDoknotStatusInnboks() {
+    prepareStatement("delete from doknotifikasjon_status_innboks").executeUpdate()
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/InnboksObjectMother.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventhandler.innboks
 
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -21,6 +22,12 @@ object InnboksObjectMother {
     val defaultLink = "https://nav.no/systemX/$defaultFodselsnummer"
     val defaultSistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo"))
     val defaultSikkerhetsnivaa = 4
+    val defaultEksternVarslinginfo = EksternVarslingInfo(
+        bestilt = false,
+        prefererteKanaler = emptyList(),
+        sendt = false,
+        sendteKanaler = emptyList()
+    )
 
 
     fun createInnboks(
@@ -38,7 +45,8 @@ object InnboksObjectMother {
         tekst: String = defaultTekst,
         link: String = defaultLink,
         sistOppdatert: ZonedDateTime = defaultSistOppdatert,
-        sikkerhetsnivaa: Int = defaultSikkerhetsnivaa
+        sikkerhetsnivaa: Int = defaultSikkerhetsnivaa,
+        eksternVarslingInfo: EksternVarslingInfo = defaultEksternVarslinginfo
     ): Innboks {
         return Innboks(
             id = id,
@@ -55,7 +63,8 @@ object InnboksObjectMother {
             link = link,
             sistOppdatert = sistOppdatert,
             sikkerhetsnivaa = sikkerhetsnivaa,
-            aktiv = aktiv
+            aktiv = aktiv,
+            eksternVarslingInfo = eksternVarslingInfo
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/innboksTestQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/innboks/innboksTestQueries.kt
@@ -4,8 +4,8 @@ import java.sql.Connection
 import java.sql.Types
 
 fun Connection.createInnboks(innbokser: List<Innboks>) =
-        prepareStatement("""INSERT INTO innboks(id, systembruker, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv, namespace, appnavn, forstBehandlet)
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")
+        prepareStatement("""INSERT INTO innboks(id, systembruker, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv, namespace, appnavn, forstBehandlet, eksternVarsling, prefererteKanaler)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")
                 .use {
                     innbokser.forEach { innboks ->
                         run {
@@ -23,6 +23,8 @@ fun Connection.createInnboks(innbokser: List<Innboks>) =
                             it.setString(12, innboks.namespace)
                             it.setString(13, innboks.appnavn)
                             it.setObject(14, innboks.forstBehandlet.toLocalDateTime(), Types.TIMESTAMP)
+                            it.setObject(15, innboks.eksternVarslingInfo.bestilt)
+                            it.setObject(16, innboks.eksternVarslingInfo.prefererteKanaler.joinToString(","))
                             it.addBatch()
                         }
                     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/OppgaveObjectMother.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.eventhandler.oppgave
 
+import no.nav.personbruker.dittnav.eventhandler.eksternvarsling.EksternVarslingInfo
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -21,6 +22,12 @@ object OppgaveObjectMother {
     val defaultLink = "https://nav.no/systemX/$defaultFodselsnummer"
     val defaultSistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo"))
     val defaultSikkerhetsnivaa = 4
+    val defaultEksternVarslinginfo = EksternVarslingInfo(
+        bestilt = false,
+        prefererteKanaler = emptyList(),
+        sendt = false,
+        sendteKanaler = emptyList()
+    )
 
     fun createOppgave(
         id: Int = ++idIncrementor,
@@ -37,7 +44,8 @@ object OppgaveObjectMother {
         sistOppdatert: ZonedDateTime = defaultSistOppdatert,
         tekst: String = defaultTekst,
         link: String = defaultLink,
-        sikkerhetsnivaa: Int = defaultSikkerhetsnivaa
+        sikkerhetsnivaa: Int = defaultSikkerhetsnivaa,
+        eksternVarslingInfo: EksternVarslingInfo = defaultEksternVarslinginfo
     ): Oppgave {
         return Oppgave(
             id = id,
@@ -54,7 +62,8 @@ object OppgaveObjectMother {
             sistOppdatert = sistOppdatert,
             tekst = tekst,
             link = link,
-            aktiv = aktiv
+            aktiv = aktiv,
+            eksternVarslingInfo = eksternVarslingInfo
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveTestQueries.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/eventhandler/oppgave/oppgaveTestQueries.kt
@@ -4,8 +4,8 @@ import java.sql.Connection
 import java.sql.Types
 
 fun Connection.createOppgave(oppgaver: List<Oppgave>) =
-        prepareStatement("""INSERT INTO oppgave(id, systembruker, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv, namespace, appnavn, forstBehandlet)
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")
+        prepareStatement("""INSERT INTO oppgave(id, systembruker, eventTidspunkt, fodselsnummer, eventId, grupperingsId, tekst, link, sikkerhetsnivaa, sistOppdatert, aktiv, namespace, appnavn, forstBehandlet, eksternVarsling, prefererteKanaler)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""")
                 .use {
                     oppgaver.forEach { oppgave ->
                         run {
@@ -23,6 +23,8 @@ fun Connection.createOppgave(oppgaver: List<Oppgave>) =
                             it.setString(12, oppgave.namespace)
                             it.setString(13, oppgave.appnavn)
                             it.setObject(14, oppgave.forstBehandlet.toLocalDateTime(), Types.TIMESTAMP)
+                            it.setObject(15, oppgave.eksternVarslingInfo.bestilt)
+                            it.setObject(16, oppgave.eksternVarslingInfo.prefererteKanaler.joinToString(","))
                             it.addBatch()
                         }
                     }

--- a/src/test/resources/db/createTablesAndViews.sql
+++ b/src/test/resources/db/createTablesAndViews.sql
@@ -1,46 +1,48 @@
 create table if not exists beskjed
 (
-  id serial not null
-    constraint beskjed_pkey
-    primary key,
-  systembruker    varchar(100),
-  eventtidspunkt  timestamp,
-  fodselsnummer   varchar(50),
-  eventid         varchar(50),
-  grupperingsid   varchar(100),
-  tekst           varchar(500),
-  link            varchar(200),
-  sikkerhetsnivaa integer,
-  sistoppdatert   timestamp,
-  aktiv           boolean,
-  synligfremtil   timestamp,
-  uid             varchar(100),
-  namespace       varchar(100),
-  appnavn         varchar(100),
-  forstbehandlet  timestamp,
-  constraint beskjedeventidprodusent
-  unique (eventid, systembruker)
+    id serial not null
+        constraint beskjed_pkey primary key,
+    systembruker        varchar(100),
+    eventtidspunkt      timestamp,
+    fodselsnummer       varchar(50),
+    eventid             varchar(50) unique,
+    grupperingsid       varchar(100),
+    tekst               varchar(500),
+    link                varchar(200),
+    sikkerhetsnivaa     integer,
+    sistoppdatert       timestamp,
+    aktiv               boolean,
+    synligfremtil       timestamp,
+    uid                 varchar(100),
+    namespace           varchar(100),
+    appnavn             varchar(100),
+    forstbehandlet      timestamp,
+    eksternVarsling     boolean,
+    prefererteKanaler   varchar(100),
+    constraint beskjedeventidprodusent
+    unique (eventid, systembruker)
 );
 
 create table if not exists oppgave
 (
-  id serial not null
-    constraint oppgave_pkey
-    primary key,
-  systembruker    varchar(100),
-  eventtidspunkt  timestamp,
-  fodselsnummer   varchar(50),
-  eventid         varchar(50),
-  grupperingsid   varchar(100),
-  tekst           varchar(500),
-  link            varchar(200),
-  sikkerhetsnivaa integer,
-  sistoppdatert   timestamp,
-  aktiv           boolean,
-  synligfremtil   timestamp,
-  namespace       varchar(100),
-  appnavn         varchar(100),
-  forstbehandlet  timestamp,
+    id serial not null
+        constraint oppgave_pkey primary key,
+    systembruker        varchar(100),
+    eventtidspunkt      timestamp,
+    fodselsnummer       varchar(50),
+    eventid             varchar(50) unique,
+    grupperingsid       varchar(100),
+    tekst               varchar(500),
+    link                varchar(200),
+    sikkerhetsnivaa     integer,
+    sistoppdatert       timestamp,
+    aktiv               boolean,
+    synligfremtil       timestamp,
+    namespace           varchar(100),
+    appnavn             varchar(100),
+    forstbehandlet      timestamp,
+    eksternVarsling     boolean,
+    prefererteKanaler   varchar(100),
   constraint oppgaveeventidprodusent
   unique (eventid, systembruker)
 );
@@ -48,12 +50,11 @@ create table if not exists oppgave
 create table if not exists innboks
 (
   id serial not null
-    constraint innboks_pkey
-    primary key,
+    constraint innboks_pkey primary key,
   systembruker    varchar(100),
   eventtidspunkt  timestamp,
   fodselsnummer   varchar(50),
-  eventid         varchar(50),
+  eventid         varchar(50) unique,
   grupperingsid   varchar(100),
   tekst           varchar(500),
   link            varchar(200),
@@ -63,6 +64,8 @@ create table if not exists innboks
   namespace       varchar(100),
   appnavn         varchar(100),
   forstbehandlet  timestamp,
+  eksternVarsling     boolean,
+  prefererteKanaler   varchar(100),
   constraint innbokseventidprodusent
   unique (eventid, systembruker)
 );
@@ -110,4 +113,37 @@ CREATE TABLE IF NOT EXISTS statusoppdatering (
     forstbehandlet timestamp,
     constraint statusoppdateringeventidprodusent
     unique (eventid, systembruker)
+);
+
+CREATE TABLE doknotifikasjon_status_beskjed (
+    eventId                 VARCHAR(50) UNIQUE,
+    status                  TEXT,
+    melding                 TEXT,
+    distribusjonsId         BIGINT,
+    tidspunkt               TIMESTAMP WITHOUT TIME ZONE,
+    kanaler                 TEXT,
+    antall_oppdateringer    SMALLINT,
+    constraint fk_dokstatus_beskjed_eventid FOREIGN KEY(eventId) REFERENCES beskjed(eventId)
+);
+
+CREATE TABLE doknotifikasjon_status_oppgave (
+    eventId                 VARCHAR(50) UNIQUE,
+    status                  TEXT,
+    melding                 TEXT,
+    distribusjonsId         BIGINT,
+    tidspunkt               TIMESTAMP WITHOUT TIME ZONE,
+    kanaler                 TEXT,
+    antall_oppdateringer    SMALLINT,
+    constraint fk_dokstatus_oppgave_eventid FOREIGN KEY(eventId) REFERENCES oppgave(eventId)
+);
+
+CREATE TABLE doknotifikasjon_status_innboks (
+    eventId                 VARCHAR(50) UNIQUE,
+    status                  TEXT,
+    melding                 TEXT,
+    distribusjonsId         BIGINT,
+    tidspunkt               TIMESTAMP WITHOUT TIME ZONE,
+    kanaler                 TEXT,
+    antall_oppdateringer    SMALLINT,
+    constraint fk_dokstatus_innboks_eventid FOREIGN KEY(eventId) REFERENCES innboks(eventId)
 );


### PR DESCRIPTION
Legger til henting av info om status på ekstern varsling for beskjed, oppgave og innboks. 

Dersom siste status på doknotifikasjon-status tilhørende en brukernotifikasjon var "OVERSENDT", anses varsel for å være sendt. En får også info om hvilke eksterne kanaler der varsel ble sendt til bruker. 

Info finnes i 2 nye felt:
 - eksternVarslingSendt
 - eksternVarslingKanaler

Grunnet endringer i api må dittnav-api, dittnav-eventer-modia og tms-event-api også oppdateres. Se lenker under.